### PR TITLE
Deprecate cassandra::java::gc

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ cassandra::java:
 
 ### Java garbage collection settings
 
+__Deprication notice:__ `cassandra::java_gc` and the class `cassandra::java::gc` are now deprecated. Consider using JVM option sets instead.
+
 Settings to Java garbage collector can be made by instanciating the `cassandra::java::gc` class. This can be done via the `java_gc` parameter of this module. E.g.:
 
 ```yaml

--- a/manifests/java/gc.pp
+++ b/manifests/java/gc.pp
@@ -1,5 +1,7 @@
 # @summary Setup the Java garbage collection for Cassandra
 #
+# Deprication notice: this class is now deprecated. Consider using JVM option sets instead.
+#
 # This class allows to set consistent JVM options at once, especially for the
 # purpose of garbage collection settings. This is enabled by managing
 # jvm.options file, available from Cassandra version 3.0 and later.
@@ -39,6 +41,7 @@ class cassandra::java::gc (
   Enum['cms','g1']  $collector,
   Hash[String,Data] $params = {},
 ) {
+  notify { 'The class cassandra::java::gc is deprecated now, consider using cassandra::jvm_option_sets instead!': }
   file{ "${cassandra::config_dir}/jvm.options":
     ensure  => file,
     content => epp("cassandra/jvm.${collector}.options.epp", $params),

--- a/spec/classes/java/32_gc_spec.rb
+++ b/spec/classes/java/32_gc_spec.rb
@@ -14,6 +14,7 @@ describe 'cassandra::java::gc' do
         end
 
         it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_notify('The class cassandra::java::gc is deprecated now, consider using cassandra::jvm_option_sets instead!') }
         it do
           is_expected.to contain_file('/etc/cassandra/jvm.options')
             .with_ensure('file')
@@ -32,6 +33,7 @@ describe 'cassandra::java::gc' do
         end
 
         it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_notify('The class cassandra::java::gc is deprecated now, consider using cassandra::jvm_option_sets instead!') }
         it do
           is_expected.to contain_file('/etc/cassandra/jvm.options')
             .with_ensure('file')
@@ -48,6 +50,7 @@ describe 'cassandra::java::gc' do
         end
 
         it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_notify('The class cassandra::java::gc is deprecated now, consider using cassandra::jvm_option_sets instead!') }
         it do
           is_expected.to contain_file('/etc/cassandra/jvm.options')
             .with_ensure('file')
@@ -69,6 +72,7 @@ describe 'cassandra::java::gc' do
         end
 
         it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_notify('The class cassandra::java::gc is deprecated now, consider using cassandra::jvm_option_sets instead!') }
         it do
           is_expected.to contain_file('/etc/cassandra/jvm.options')
             .with_ensure('file')


### PR DESCRIPTION
Using `cassandra::java::gc` is only available for Cassandra versions 3.0 and later, will collide with `cassandra::jvm_option_sets` and can be fully replaced with it.