### PR TITLE
Make type enforcement less restrictive

### DIFF
--- a/manifests/java/advancedruntimeoption.pp
+++ b/manifests/java/advancedruntimeoption.pp
@@ -23,7 +23,7 @@
 #   which will prefix the option with + or -
 #
 define cassandra::java::advancedruntimeoption (
-  Variant[Boolean,String] $value,
+  Scalar $value,
 ) {
   $_opt = $value ? {
     Boolean => inline_epp('XX:<% if $value { -%>+<% } else { -%>-<% } -%><%= $name %>',
@@ -31,12 +31,11 @@ define cassandra::java::advancedruntimeoption (
         'name'  => $name,
         'value' => $value,
       }),
-    String  => inline_epp('XX:<%= $name -%>=<%= $value %>',
+    default  => inline_epp('XX:<%= $name -%>=<%= $value %>',
       {
         'name'  => $name,
         'value' => $value,
       }),
-    default => '',
   }
   cassandra::environment::jvm_option { $_opt: }
 }

--- a/manifests/java/property.pp
+++ b/manifests/java/property.pp
@@ -21,7 +21,7 @@
 #   the value the property is set to
 #
 define cassandra::java::property (
-  String $value,
+  Scalar $value,
 ) {
   cassandra::environment::jvm_option{ "D${name}=${value}": }
 }

--- a/manifests/java/runtimeoption.pp
+++ b/manifests/java/runtimeoption.pp
@@ -19,7 +19,7 @@
 #   value to be added to the runtime option 
 #
 define cassandra::java::runtimeoption (
-  Optional[String] $value = undef,
+  Optional[Scalar] $value = undef,
 ) {
   $_opt = inline_epp('X<%= $prop -%><% if $value { -%>:<%= $value -%><% } -%>',
     {

--- a/spec/defines/java/35_advancedruntimeoption_spec.rb
+++ b/spec/defines/java/35_advancedruntimeoption_spec.rb
@@ -48,6 +48,20 @@ describe 'cassandra::java::advancedruntimeoption' do
           is_expected.to contain_cassandra__environment__jvm_option('XX:Option=Parameter')
         end
       end
+
+      context 'option integer parameter' do
+        let(:title) { 'Option' }
+        let(:params) do
+          {
+            'value' => 1234,
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it do
+          is_expected.to contain_cassandra__environment__jvm_option('XX:Option=1234')
+        end
+      end
     end
   end
 end

--- a/spec/defines/java/35_property_spec.rb
+++ b/spec/defines/java/35_property_spec.rb
@@ -2,20 +2,62 @@ require 'spec_helper'
 
 describe 'cassandra::java::property' do
   let(:pre_condition) { 'include cassandra' }
-  let(:title) { 'testproperty' }
-  let(:params) do
-    {
-      'value' => 'testvalue',
-    }
-  end
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { is_expected.to compile }
-      it do
-        is_expected.to contain_cassandra__environment__jvm_option('Dtestproperty=testvalue')
+      describe 'string property' do
+        let(:title) { 'strproperty' }
+        let(:params) do
+          {
+            'value' => 'testvalue',
+          }
+        end
+      
+        it { is_expected.to compile }
+        it do
+          is_expected.to contain_cassandra__environment__jvm_option('Dstrproperty=testvalue')
+        end
+      end
+      describe 'integer property' do
+        let(:title) { 'intproperty' }
+        let(:params) do
+          {
+            'value' => 1234,
+          }
+        end
+      
+        it { is_expected.to compile }
+        it do
+          is_expected.to contain_cassandra__environment__jvm_option('Dintproperty=1234')
+        end
+      end
+      describe 'boolean property true' do
+        let(:title) { 'boolproperty1' }
+        let(:params) do
+          {
+            'value' => true,
+          }
+        end
+      
+        it { is_expected.to compile }
+        it do
+          is_expected.to contain_cassandra__environment__jvm_option('Dboolproperty1=true')
+        end
+      end
+      describe 'boolean property false' do
+        let(:title) { 'boolproperty0' }
+        let(:params) do
+          {
+            'value' => false,
+          }
+        end
+      
+        it { is_expected.to compile }
+        it do
+          is_expected.to contain_cassandra__environment__jvm_option('Dboolproperty0=false')
+        end
       end
     end
   end

--- a/spec/defines/java/35_property_spec.rb
+++ b/spec/defines/java/35_property_spec.rb
@@ -14,7 +14,7 @@ describe 'cassandra::java::property' do
             'value' => 'testvalue',
           }
         end
-      
+
         it { is_expected.to compile }
         it do
           is_expected.to contain_cassandra__environment__jvm_option('Dstrproperty=testvalue')
@@ -27,7 +27,7 @@ describe 'cassandra::java::property' do
             'value' => 1234,
           }
         end
-      
+
         it { is_expected.to compile }
         it do
           is_expected.to contain_cassandra__environment__jvm_option('Dintproperty=1234')
@@ -40,7 +40,7 @@ describe 'cassandra::java::property' do
             'value' => true,
           }
         end
-      
+
         it { is_expected.to compile }
         it do
           is_expected.to contain_cassandra__environment__jvm_option('Dboolproperty1=true')
@@ -53,7 +53,7 @@ describe 'cassandra::java::property' do
             'value' => false,
           }
         end
-      
+
         it { is_expected.to compile }
         it do
           is_expected.to contain_cassandra__environment__jvm_option('Dboolproperty0=false')

--- a/spec/defines/java/35_runtimeoption_spec.rb
+++ b/spec/defines/java/35_runtimeoption_spec.rb
@@ -16,7 +16,7 @@ describe 'cassandra::java::runtimeoption' do
         end
       end
 
-      context 'option /w parameter' do
+      context 'option /w string parameter' do
         let(:title) { 'testoption2' }
         let(:params) do
           {
@@ -27,6 +27,32 @@ describe 'cassandra::java::runtimeoption' do
         it { is_expected.to compile }
         it do
           is_expected.to contain_cassandra__environment__jvm_option('Xtestoption2:testvalue')
+        end
+      end
+      context 'option /w integer parameter' do
+        let(:title) { 'testoption3' }
+        let(:params) do
+          {
+            'value' => 1234,
+          }
+        end
+
+        it { is_expected.to compile }
+        it do
+          is_expected.to contain_cassandra__environment__jvm_option('Xtestoption3:1234')
+        end
+      end
+      context 'option /w boolean parameter' do
+        let(:title) { 'testoption4' }
+        let(:params) do
+          {
+            'value' => true,
+          }
+        end
+
+        it { is_expected.to compile }
+        it do
+          is_expected.to contain_cassandra__environment__jvm_option('Xtestoption4:true')
         end
       end
     end


### PR DESCRIPTION
Type enforcement in many `cassandra::java` resources is to restrictive. This allows Integer and Boolean types for many property and option values.