### PR TITLE
Migrate CI/CD to GHA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+env:
+  HONEYCOMB_WRITEKEY: "${{ secrets.HONEYCOMB_WRITEKEY }}"
+  HONEYCOMB_DATASET: puppet-cassandra
 jobs:
   static:
     name: static checks
@@ -74,3 +77,41 @@ jobs:
 
       - name: Spec tests
         run: bundle exec rake parallel_spec
+  acceptance:
+    needs: spec
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        collection: ['puppet6']
+        provision:
+          - deb_c21
+          - deb_c22
+          - deb_c30
+          - deb_c311
+          # - deb_c40
+    name: Litmus tests for ${{ matrix.provision }} with ${{ matrix.collection }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.5.7
+
+      - name: Prepare environment
+        run: |
+          bundle config set --local with 'system_tests'
+          bundle install
+
+      - name: Provision test environment
+        run: bundle exec rake 'litmus:provision_list[${{ matrix.provision }}]'
+
+      - name: Install Agent
+        run: bundle exec rake 'litmus:install_agent[${{ matrix.collection }}]'
+
+      - name: Install Module
+        run: bundle exec rake 'litmus:install_module'
+
+      - name: Running acceptance tests
+        run: bundle exec rake 'litmus:acceptance:parallel'

--- a/provision.yaml
+++ b/provision.yaml
@@ -1,21 +1,21 @@
 ---
-travis_deb_c21:
+deb_c21:
   provisioner: docker
   images: ['litmusimage/debian:9', 'litmusimage/ubuntu:18.04']
   vars: '{apt_sources_list: cassandra_21x.sources.list}'
-travis_deb_c22:
+deb_c22:
   provisioner: docker
   images: ['litmusimage/debian:9', 'litmusimage/ubuntu:18.04']
   vars: '{apt_sources_list: cassandra_22x.sources.list}'
-travis_deb_c30:
+deb_c30:
   provisioner: docker
   images: ['litmusimage/debian:9', 'litmusimage/ubuntu:16.04', 'litmusimage/ubuntu:18.04']
   vars: '{apt_sources_list: cassandra_30x.sources.list}'
-travis_deb_c311:
+deb_c311:
   provisioner: docker
   images: ['litmusimage/debian:9', 'litmusimage/ubuntu:16.04', 'litmusimage/ubuntu:18.04']
   vars: '{apt_sources_list: cassandra_311x.sources.list}'
-travis_deb_c40:
+deb_c40:
   provisioner: docker
   images: ['litmusimage/debian:9', 'litmusimage/debian:10', 'litmusimage/ubuntu:16.04', 'litmusimage/ubuntu:18.04']
   vars: '{apt_sources_list: cassandra_40x.sources.list}'


### PR DESCRIPTION
As Travis-CI.org is shutting down, this is the first task to migrate CI/CD pipeline to GHA.