### PR TITLE
change default value service enable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,7 +63,7 @@ class cassandra (
   String                      $tools_ensure = $cassandra_ensure,
   Boolean                     $manage_service = true,
   Cassandra::Service::Ensure  $service_ensure = undef,
-  Cassandra::Service::Enable  $service_enable = 'manual',
+  Cassandra::Service::Enable  $service_enable = false,
   String                      $service_name = 'cassandra',
   Stdlib::Absolutepath        $config_dir = '/etc/cassandra',
   Hash                        $environment = {},

--- a/spec/classes/40_service_spec.rb
+++ b/spec/classes/40_service_spec.rb
@@ -11,7 +11,7 @@ describe 'cassandra' do
           it do
             is_expected.to contain_service('cassandra')
               .without_ensure
-              .with_enable('manual')
+              .with_enable(false)
           end
         end
         context 'service enabled and running setup' do


### PR DESCRIPTION
Spec tests were broken sind Puppet releases 6.23.0 and 7.8.0 due to some property validation enforcement. This is changing the default value of service_enable parameter from `manual`, which is only supported by systemd provider, to `false`, which is supported by many service providers.

Mind the change of default behaviour.